### PR TITLE
Use canonical HTTPS URL for Git repository in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Then clone this repository:
 
 ```
   $ cd <SITENAME>/themes
-  $ git clone http://github.com/karju-dev/airspace-hugo/
+  $ git clone https://github.com/karju-dev/airspace-hugo.git
 ```
 
 Now take a look at the exampleSite folder and you're ready to go! 


### PR DESCRIPTION
This is what GitHub provides when one clicks on the green "Clone or download" button.

Thanks!  :-)