### PR TITLE
Fix dateFormat on exampleSite.

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -50,7 +50,7 @@ theme = "airspace-hugo"
   # This license is offered with a 50% discount for all Hugo users.
   # For information see https://github.com/gohugoio/hugoThemes/issues/260
 
-  date_format = "6 January 2006"
+  date_format = "2 January 2006"
 
   home = "Home"
 


### PR DESCRIPTION
Example days must be "2" see https://www.madboa.com/blog/2016/08/24/hugo-dateformat/#the-format-string-trick

Without this the date's in the blog posts always have the day "6". 