### PR TITLE
Always load jQuery over HTTPS (safer and faster)

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -20,7 +20,7 @@
 <link rel="stylesheet" href="{{ .Site.BaseURL }}css/syntax.css" />
 
 <!-- Js -->
-<script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.10.2.min.js"><\/script>')</script>
 <script src="{{ .Site.BaseURL }}js/bootstrap.min.js"></script>
 <script src="{{ .Site.BaseURL }}js/owl.carousel.min.js"></script>


### PR DESCRIPTION
This pull request makes a small update to the way jQuery is loaded in the `layouts/partials/head.html` file. The protocol-relative URL for the jQuery CDN has been replaced with an explicit `https` URL to ensure the script is always loaded securely.